### PR TITLE
Add API call to get product list 📃 

### DIFF
--- a/BlackMarket.xcodeproj/project.pbxproj
+++ b/BlackMarket.xcodeproj/project.pbxproj
@@ -7,6 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7533184A2AC4ABA5000E3242 /* RSRequestResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 753318492AC4ABA5000E3242 /* RSRequestResponse.swift */; };
+		7533184C2AC4ABFA000E3242 /* RSAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7533184B2AC4ABFA000E3242 /* RSAPIError.swift */; };
+		755D3D4D2AC4BC5C0066C18F /* RSSwiftNetworking in Frameworks */ = {isa = PBXBuildFile; productRef = 755D3D4C2AC4BC5C0066C18F /* RSSwiftNetworking */; };
+		755D3D4F2AC4BC5C0066C18F /* RSSwiftNetworkingAlamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 755D3D4E2AC4BC5C0066C18F /* RSSwiftNetworkingAlamofire */; };
+		755D3D522AC5E3D50066C18F /* ProductServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755D3D512AC5E3D50066C18F /* ProductServices.swift */; };
+		755D3D542AC5E5E70066C18F /* PagedResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755D3D532AC5E5E70066C18F /* PagedResponse.swift */; };
+		755D3D5C2AC5EBF10066C18F /* ProductEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755D3D5B2AC5EBF10066C18F /* ProductEndpoint.swift */; };
+		755D3D602AC603D20066C18F /* ProductsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755D3D5F2AC603D20066C18F /* ProductsManager.swift */; };
+		755D3D622AC609B00066C18F /* DashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755D3D612AC609B00066C18F /* DashboardViewModel.swift */; };
 		756269582AC1B92B00692D5C /* FavouriteList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 756269572AC1B92B00692D5C /* FavouriteList.swift */; };
 		7562695B2AC1C0D400692D5C /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7562695A2AC1C0D400692D5C /* DashboardView.swift */; };
 		7572F4E82AC3727000913D4E /* SearchProductsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7572F4E72AC3727000913D4E /* SearchProductsView.swift */; };
@@ -17,12 +26,17 @@
 		7572F4F22AC3773300913D4E /* PromoShipmentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7572F4F12AC3773300913D4E /* PromoShipmentsView.swift */; };
 		7572F4F52AC37ECD00913D4E /* HeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7572F4F42AC37ECD00913D4E /* HeaderView.swift */; };
 		7574EAEA2ABE207200234876 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7574EAE92ABE207200234876 /* String.swift */; };
+		7576C2852AC4B021001795BC /* RSApiClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7576C2842AC4B021001795BC /* RSApiClient.swift */; };
+		7576C2872AC4B062001795BC /* RSNetworkProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7576C2862AC4B062001795BC /* RSNetworkProvider.swift */; };
+		7576C28A2AC4B0F8001795BC /* RSApiClient+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7576C2892AC4B0F8001795BC /* RSApiClient+Extension.swift */; };
+		7576C2912AC4B399001795BC /* SessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7576C2902AC4B399001795BC /* SessionManager.swift */; };
 		758112762AC30381004819DB /* TabbedItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 758112752AC30381004819DB /* TabbedItems.swift */; };
 		758112782AC305FA004819DB /* MainTabbedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 758112772AC305FA004819DB /* MainTabbedView.swift */; };
 		7581127D2AC3120A004819DB /* ShoppingCartList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7581127C2AC3120A004819DB /* ShoppingCartList.swift */; };
 		7581127F2AC31227004819DB /* PurchasesList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7581127E2AC31227004819DB /* PurchasesList.swift */; };
 		758112812AC31236004819DB /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 758112802AC31236004819DB /* Settings.swift */; };
 		758112842AC339AF004819DB /* ImageNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = 758112832AC339AF004819DB /* ImageNames.swift */; };
+		75AB79C12AC617CF00D9D855 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75AB79C02AC617CF00D9D855 /* Constants.swift */; };
 		75D552A32AB8BCBA0043D887 /* BlackMarketApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75D552A22AB8BCBA0043D887 /* BlackMarketApp.swift */; };
 		75D552A52AB8BCBA0043D887 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75D552A42AB8BCBA0043D887 /* ContentView.swift */; };
 		75D552A72AB8BCBB0043D887 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 75D552A62AB8BCBB0043D887 /* Assets.xcassets */; };
@@ -40,14 +54,14 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		75D552B02AB8BCBB0043D887 /* PBXContainerItemProxy */ = {
+		75E17E1D2ACC68AE003FA3F1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 75D552972AB8BCBA0043D887 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 75D5529E2AB8BCBA0043D887;
 			remoteInfo = BlackMarket;
 		};
-		75D552BA2AB8BCBC0043D887 /* PBXContainerItemProxy */ = {
+		75E17E1F2ACC68B8003FA3F1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 75D552972AB8BCBA0043D887 /* Project object */;
 			proxyType = 1;
@@ -57,6 +71,14 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		753318492AC4ABA5000E3242 /* RSRequestResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSRequestResponse.swift; sourceTree = "<group>"; };
+		7533184B2AC4ABFA000E3242 /* RSAPIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSAPIError.swift; sourceTree = "<group>"; };
+		755D3D512AC5E3D50066C18F /* ProductServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductServices.swift; sourceTree = "<group>"; };
+		755D3D532AC5E5E70066C18F /* PagedResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagedResponse.swift; sourceTree = "<group>"; };
+		755D3D5B2AC5EBF10066C18F /* ProductEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEndpoint.swift; sourceTree = "<group>"; };
+		755D3D5D2AC602200066C18F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		755D3D5F2AC603D20066C18F /* ProductsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsManager.swift; sourceTree = "<group>"; };
+		755D3D612AC609B00066C18F /* DashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewModel.swift; sourceTree = "<group>"; };
 		756269572AC1B92B00692D5C /* FavouriteList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavouriteList.swift; sourceTree = "<group>"; };
 		7562695A2AC1C0D400692D5C /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
 		7572F4E72AC3727000913D4E /* SearchProductsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchProductsView.swift; sourceTree = "<group>"; };
@@ -67,12 +89,17 @@
 		7572F4F12AC3773300913D4E /* PromoShipmentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoShipmentsView.swift; sourceTree = "<group>"; };
 		7572F4F42AC37ECD00913D4E /* HeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderView.swift; sourceTree = "<group>"; };
 		7574EAE92ABE207200234876 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
+		7576C2842AC4B021001795BC /* RSApiClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSApiClient.swift; sourceTree = "<group>"; };
+		7576C2862AC4B062001795BC /* RSNetworkProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSNetworkProvider.swift; sourceTree = "<group>"; };
+		7576C2892AC4B0F8001795BC /* RSApiClient+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RSApiClient+Extension.swift"; sourceTree = "<group>"; };
+		7576C2902AC4B399001795BC /* SessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManager.swift; sourceTree = "<group>"; };
 		758112752AC30381004819DB /* TabbedItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedItems.swift; sourceTree = "<group>"; };
 		758112772AC305FA004819DB /* MainTabbedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabbedView.swift; sourceTree = "<group>"; };
 		7581127C2AC3120A004819DB /* ShoppingCartList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppingCartList.swift; sourceTree = "<group>"; };
 		7581127E2AC31227004819DB /* PurchasesList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesList.swift; sourceTree = "<group>"; };
 		758112802AC31236004819DB /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
 		758112832AC339AF004819DB /* ImageNames.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageNames.swift; sourceTree = "<group>"; };
+		75AB79C02AC617CF00D9D855 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		75D5529F2AB8BCBA0043D887 /* BlackMarket.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BlackMarket.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		75D552A22AB8BCBA0043D887 /* BlackMarketApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BlackMarketApp.swift; path = ../BlackMarketApp.swift; sourceTree = "<group>"; };
 		75D552A42AB8BCBA0043D887 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -97,6 +124,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				755D3D4F2AC4BC5C0066C18F /* RSSwiftNetworkingAlamofire in Frameworks */,
+				755D3D4D2AC4BC5C0066C18F /* RSSwiftNetworking in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -131,6 +160,45 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
+		753318482AC4AB44000E3242 /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				755D3D5A2AC5EBC30066C18F /* Endpoints */,
+				755D3D592AC5E6930066C18F /* Model */,
+				755D3D502AC5E3AC0066C18F /* Services */,
+				7576C2882AC4B0AC001795BC /* Extensions */,
+				7576C2842AC4B021001795BC /* RSApiClient.swift */,
+				753318492AC4ABA5000E3242 /* RSRequestResponse.swift */,
+				7533184B2AC4ABFA000E3242 /* RSAPIError.swift */,
+				7576C2862AC4B062001795BC /* RSNetworkProvider.swift */,
+			);
+			path = Networking;
+			sourceTree = "<group>";
+		};
+		755D3D502AC5E3AC0066C18F /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				755D3D512AC5E3D50066C18F /* ProductServices.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
+		755D3D592AC5E6930066C18F /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				755D3D532AC5E5E70066C18F /* PagedResponse.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		755D3D5A2AC5EBC30066C18F /* Endpoints */ = {
+			isa = PBXGroup;
+			children = (
+				755D3D5B2AC5EBF10066C18F /* ProductEndpoint.swift */,
+			);
+			path = Endpoints;
+			sourceTree = "<group>";
+		};
 		756269592AC1BF4100692D5C /* Dashboard */ = {
 			isa = PBXGroup;
 			children = (
@@ -141,6 +209,7 @@
 				7572F4ED2AC3731C00913D4E /* PaymentMethodsView.swift */,
 				7572F4EF2AC376D200913D4E /* ProductItemView.swift */,
 				7572F4F12AC3773300913D4E /* PromoShipmentsView.swift */,
+				755D3D612AC609B00066C18F /* DashboardViewModel.swift */,
 			);
 			path = Dashboard;
 			sourceTree = "<group>";
@@ -151,6 +220,23 @@
 				756269572AC1B92B00692D5C /* FavouriteList.swift */,
 			);
 			path = Favourite;
+			sourceTree = "<group>";
+		};
+		7576C2882AC4B0AC001795BC /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				7576C2892AC4B0F8001795BC /* RSApiClient+Extension.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		7576C28D2AC4B300001795BC /* Managers */ = {
+			isa = PBXGroup;
+			children = (
+				7576C2902AC4B399001795BC /* SessionManager.swift */,
+				755D3D5F2AC603D20066C18F /* ProductsManager.swift */,
+			);
+			path = Managers;
 			sourceTree = "<group>";
 		};
 		758112742AC30344004819DB /* TabBar */ = {
@@ -210,6 +296,8 @@
 		75D552A12AB8BCBA0043D887 /* BlackMarket */ = {
 			isa = PBXGroup;
 			children = (
+				7576C28D2AC4B300001795BC /* Managers */,
+				753318482AC4AB44000E3242 /* Networking */,
 				750305CC2ABDFDCE00905526 /* Views */,
 				75DE8DBD2ABDEDD500285F4D /* Preview Content */,
 				75DE8DBA2ABDDEBE00285F4D /* Application */,
@@ -219,6 +307,7 @@
 				75D552CF2AB8CE580043D887 /* Resources */,
 				75D552A42AB8BCBA0043D887 /* ContentView.swift */,
 				75D552A62AB8BCBB0043D887 /* Assets.xcassets */,
+				755D3D5D2AC602200066C18F /* Info.plist */,
 			);
 			path = BlackMarket;
 			sourceTree = "<group>";
@@ -254,6 +343,7 @@
 			children = (
 				75DE8DA02AB9E9BE00285F4D /* ViewHelpers.swift */,
 				758112832AC339AF004819DB /* ImageNames.swift */,
+				75AB79C02AC617CF00D9D855 /* Constants.swift */,
 			);
 			path = Commons;
 			sourceTree = "<group>";
@@ -308,6 +398,10 @@
 			dependencies = (
 			);
 			name = BlackMarket;
+			packageProductDependencies = (
+				755D3D4C2AC4BC5C0066C18F /* RSSwiftNetworking */,
+				755D3D4E2AC4BC5C0066C18F /* RSSwiftNetworkingAlamofire */,
+			);
 			productName = BlackMarket;
 			productReference = 75D5529F2AB8BCBA0043D887 /* BlackMarket.app */;
 			productType = "com.apple.product-type.application";
@@ -323,7 +417,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				75D552B12AB8BCBB0043D887 /* PBXTargetDependency */,
+				75E17E1E2ACC68AE003FA3F1 /* PBXTargetDependency */,
 			);
 			name = BlackMarketTests;
 			productName = BlackMarketTests;
@@ -341,7 +435,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				75D552BB2AB8BCBC0043D887 /* PBXTargetDependency */,
+				75E17E202ACC68B8003FA3F1 /* PBXTargetDependency */,
 			);
 			name = BlackMarketUITests;
 			productName = BlackMarketUITests;
@@ -356,7 +450,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1430;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1500;
 				TargetAttributes = {
 					75D5529E2AB8BCBA0043D887 = {
 						CreatedOnToolsVersion = 14.3.1;
@@ -380,6 +474,9 @@
 				Base,
 			);
 			mainGroup = 75D552962AB8BCBA0043D887;
+			packageReferences = (
+				755D3D4B2AC4BC5C0066C18F /* XCRemoteSwiftPackageReference "RSSwiftNetworking" */,
+			);
 			productRefGroup = 75D552A02AB8BCBA0043D887 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -424,14 +521,24 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				755D3D602AC603D20066C18F /* ProductsManager.swift in Sources */,
 				7572F4F22AC3773300913D4E /* PromoShipmentsView.swift in Sources */,
 				7581127F2AC31227004819DB /* PurchasesList.swift in Sources */,
+				755D3D622AC609B00066C18F /* DashboardViewModel.swift in Sources */,
+				7576C2872AC4B062001795BC /* RSNetworkProvider.swift in Sources */,
 				7581127D2AC3120A004819DB /* ShoppingCartList.swift in Sources */,
 				75D552A52AB8BCBA0043D887 /* ContentView.swift in Sources */,
+				7533184C2AC4ABFA000E3242 /* RSAPIError.swift in Sources */,
+				755D3D522AC5E3D50066C18F /* ProductServices.swift in Sources */,
 				7562695B2AC1C0D400692D5C /* DashboardView.swift in Sources */,
+				7576C2912AC4B399001795BC /* SessionManager.swift in Sources */,
 				758112812AC31236004819DB /* Settings.swift in Sources */,
+				7576C28A2AC4B0F8001795BC /* RSApiClient+Extension.swift in Sources */,
+				755D3D5C2AC5EBF10066C18F /* ProductEndpoint.swift in Sources */,
 				7572F4F52AC37ECD00913D4E /* HeaderView.swift in Sources */,
+				7533184A2AC4ABA5000E3242 /* RSRequestResponse.swift in Sources */,
 				758112842AC339AF004819DB /* ImageNames.swift in Sources */,
+				7576C2852AC4B021001795BC /* RSApiClient.swift in Sources */,
 				7572F4EC2AC372FC00913D4E /* PromoDiscountView.swift in Sources */,
 				75DE8DA12AB9E9BE00285F4D /* ViewHelpers.swift in Sources */,
 				75DE8DA72ABB468F00285F4D /* Product.swift in Sources */,
@@ -446,6 +553,8 @@
 				75DE8DBC2ABDDF0000285F4D /* LocalizedString.swift in Sources */,
 				758112762AC30381004819DB /* TabbedItems.swift in Sources */,
 				75D552A32AB8BCBA0043D887 /* BlackMarketApp.swift in Sources */,
+				755D3D542AC5E5E70066C18F /* PagedResponse.swift in Sources */,
+				75AB79C12AC617CF00D9D855 /* Constants.swift in Sources */,
 				758112782AC305FA004819DB /* MainTabbedView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -470,15 +579,15 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		75D552B12AB8BCBB0043D887 /* PBXTargetDependency */ = {
+		75E17E1E2ACC68AE003FA3F1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 75D5529E2AB8BCBA0043D887 /* BlackMarket */;
-			targetProxy = 75D552B02AB8BCBB0043D887 /* PBXContainerItemProxy */;
+			targetProxy = 75E17E1D2ACC68AE003FA3F1 /* PBXContainerItemProxy */;
 		};
-		75D552BB2AB8BCBC0043D887 /* PBXTargetDependency */ = {
+		75E17E202ACC68B8003FA3F1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 75D5529E2AB8BCBA0043D887 /* BlackMarket */;
-			targetProxy = 75D552BA2AB8BCBC0043D887 /* PBXContainerItemProxy */;
+			targetProxy = 75E17E1F2ACC68B8003FA3F1 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -487,6 +596,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -519,6 +629,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -547,6 +658,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -579,6 +691,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -602,11 +715,15 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				BASE_URL = "";
+				"BASE_URL[arch=*]" = "https://black-market-juan-rs.herokuapp.com";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"BlackMarket/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = BlackMarket/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -619,9 +736,12 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.example-app.BlackMarket";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -630,11 +750,15 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				BASE_URL = "";
+				"BASE_URL[arch=*]" = "https://black-market-juan-rs.herokuapp.com";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"BlackMarket/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = BlackMarket/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -647,9 +771,12 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.example-app.BlackMarket";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};
@@ -701,6 +828,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.example-app.BlackMarketUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -718,6 +846,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.example-app.BlackMarketUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -765,6 +894,30 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		755D3D4B2AC4BC5C0066C18F /* XCRemoteSwiftPackageReference "RSSwiftNetworking" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/rootstrap/RSSwiftNetworking";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		755D3D4C2AC4BC5C0066C18F /* RSSwiftNetworking */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 755D3D4B2AC4BC5C0066C18F /* XCRemoteSwiftPackageReference "RSSwiftNetworking" */;
+			productName = RSSwiftNetworking;
+		};
+		755D3D4E2AC4BC5C0066C18F /* RSSwiftNetworkingAlamofire */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 755D3D4B2AC4BC5C0066C18F /* XCRemoteSwiftPackageReference "RSSwiftNetworking" */;
+			productName = RSSwiftNetworkingAlamofire;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 75D552972AB8BCBA0043D887 /* Project object */;
 }

--- a/BlackMarket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BlackMarket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "b2fa556e4e48cbf06cf8c63def138c98f4b811fa",
+        "version" : "5.8.0"
+      }
+    },
+    {
+      "identity" : "rsswiftnetworking",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/rootstrap/RSSwiftNetworking",
+      "state" : {
+        "branch" : "main",
+        "revision" : "c1a44b60c4e949092629948158a2b27472a5e0be"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/BlackMarket/Commons/Constants.swift
+++ b/BlackMarket/Commons/Constants.swift
@@ -1,0 +1,14 @@
+//
+//  Constants.swift
+//  BlackMarket
+//
+//  Created by Santiago Andracchi on 28/09/2023.
+//
+
+import Foundation
+
+enum ProductsPaging {
+  static let defaultPage = 1
+  static let dashboardPageSize = 0
+  static let defaultSearch = ""
+}

--- a/BlackMarket/Info.plist
+++ b/BlackMarket/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Base URL</key>
+	<string>$(BASE_URL)</string>
+</dict>
+</plist>

--- a/BlackMarket/Managers/ProductsManager.swift
+++ b/BlackMarket/Managers/ProductsManager.swift
@@ -1,0 +1,44 @@
+//
+//  ProductsManager.swift
+//  BlackMarket
+//
+//  Created by Santiago Andracchi on 28/09/2023.
+//
+
+import Foundation
+
+final class ProductsManager: ObservableObject {
+  
+  @Published private(set) var products: [Product] = []
+  @Published private(set) var errorMessage: RSAPIError? = nil
+  @Published var totalNumberOfProducts: Int = 0
+  
+  private let service: ProductServicesProtocol
+  private let pageSize: Int
+  private var currentPage: Int = ProductsPaging.defaultPage
+  private var currentSearch: String = ProductsPaging.defaultSearch
+  var isLastPage: Bool = false
+  
+  init(service: ProductServicesProtocol, pageSize: Int) {
+    self.service = service
+    self.pageSize = pageSize
+  }
+  
+  @MainActor
+  func getProducts() async {
+    let response = await service.getProducts(
+      page: currentPage,
+      pageSize: pageSize,
+      search: currentSearch
+    )
+    switch response {
+    case .success(let productResponse):
+      currentPage += 1
+      products.append(contentsOf: productResponse.results)
+      isLastPage = productResponse.count == products.count
+      totalNumberOfProducts = productResponse.count
+    case .failure(let error):
+      errorMessage = error
+    }
+  }
+}

--- a/BlackMarket/Managers/SessionManager.swift
+++ b/BlackMarket/Managers/SessionManager.swift
@@ -1,0 +1,82 @@
+//
+//  Constaints.swift
+//  swiftui-base
+//
+//  Created by Karen Stoletniy on 06/9/22.
+//
+
+import SwiftUI
+import Combine
+
+internal final class SessionManager {
+  
+  var isSessionValidPublisher: AnyPublisher<Bool, Never> {
+    currentSessionTokenPublisher
+      .filter { _ in self.publishTokenState }
+      .map { $0 != nil }
+      .eraseToAnyPublisher()
+  }
+  
+  private var currentSessionTokenPublisher: AnyPublisher<String?, Never> {
+    userDefaults.publisher(for: \.currentSessionToken).eraseToAnyPublisher()
+  }
+  
+  private var subscriptions = Set<AnyCancellable>()
+  
+  static let shared = SessionManager()
+  
+  private let userDefaults: UserDefaults
+  private var publishTokenState: Bool = true
+  
+  init(userDefaults: UserDefaults = .standard) {
+    self.userDefaults = userDefaults
+  }
+  
+  private(set) var accessToken: String? {
+    get {
+      userDefaults.currentSessionToken
+    }
+    set {
+      userDefaults.currentSessionToken = newValue
+    }
+  }
+  
+  @MainActor
+  func saveSession(withToken token: String?, publishState: Bool = true) {
+    self.publishTokenState = publishState
+    accessToken = token
+  }
+  
+  func deleteSession(publishState: Bool = true) {
+    self.publishTokenState = publishState
+    accessToken = nil
+  }
+  
+  func getHeaders() -> [String: String] {
+    return [
+      "Authorization": "bearer \(accessToken ?? "")",
+      "x-platform": "ios"
+    ]
+  }
+}
+
+enum SessionKey {
+  static let userAccessToken = "rs-admin-access-token"
+}
+
+fileprivate extension UserDefaults {
+  
+  static let SESSION_KEY = SessionKey.userAccessToken
+  
+  @objc dynamic var currentSessionToken: String? {
+    get {
+      if let token = string(forKey: SessionKey.userAccessToken) {
+        return token
+      }
+      return nil
+    }
+    set {
+      set(newValue, forKey: SessionKey.userAccessToken)
+    }
+  }
+}

--- a/BlackMarket/Networking/Endpoints/ProductEndpoint.swift
+++ b/BlackMarket/Networking/Endpoints/ProductEndpoint.swift
@@ -1,0 +1,70 @@
+//
+//  ProductsEndpoint.swift
+//  BlackMarket
+//
+//  Created by Santiago Andracchi on 28/09/2023.
+//
+
+import Foundation
+import RSSwiftNetworking
+
+internal enum ProductEndpoint: RailsAPIEndpoint {
+  
+  case getProducts(
+    page: Int,
+    pageSize: Int,
+    search: String?
+  )
+  
+  case getFavorites
+  
+  private static let productsURL = "api/products"
+  private static let favoriteURL = ProductEndpoint.productsURL + "/favorites"
+  
+  var path: String {
+    switch self {
+    case .getProducts:
+      return ProductEndpoint.productsURL
+    case .getFavorites:
+      return ProductEndpoint.favoriteURL
+    }
+  }
+  
+  var method: Network.HTTPMethod {
+    switch self {
+    case .getProducts, .getFavorites:
+      return .get
+    }
+  }
+  
+  var parameters: [String : Any] {
+    switch self {
+    case .getProducts(let page, let pageSize, let search):
+      return [
+        "page": page,
+        "page_size": pageSize,
+        "search": search ?? ""
+      ]
+    default:
+      return [:]
+    }
+  }
+  
+  var headers: [String : String] {
+    return [
+      HTTPHeader.accept.rawValue: "*/*",
+      HTTPHeader.contentType.rawValue: "application/json",
+      // TODO: Use session manager properly after login
+      "Cookie" : "black-market-app-auth=; black-market-refresh-token=; csrftoken=; sessionid=;"
+    ]
+  }
+  
+  var parameterEncoding: ParameterEncoding {
+    switch self {
+    case .getFavorites, .getProducts:
+      return .urlQuery
+    default:
+      return .httpBody(.json)
+    }
+  }
+}

--- a/BlackMarket/Networking/Extensions/RSApiClient+Extension.swift
+++ b/BlackMarket/Networking/Extensions/RSApiClient+Extension.swift
@@ -1,0 +1,16 @@
+//
+//  RSApiClient+Extension.swift
+//  BlackMarket
+//
+//  Created by Santiago Andracchi on 27/09/2023.
+//
+
+import Foundation
+import RSSwiftNetworking
+import RSSwiftNetworkingAlamofire
+
+extension RSApiClient {
+  static let shared = RSApiClient(
+    networkProvider: RSNetworkProvider()
+  )
+}

--- a/BlackMarket/Networking/Model/PagedResponse.swift
+++ b/BlackMarket/Networking/Model/PagedResponse.swift
@@ -1,0 +1,13 @@
+//
+//  PagedResponse.swift
+//  BlackMarket
+//
+//  Created by Santiago Andracchi on 28/09/2023.
+//
+
+import Foundation
+
+struct PagedResponse<T: Decodable>: Decodable {
+  let results: T
+  let count: Int
+}

--- a/BlackMarket/Networking/RSAPIError.swift
+++ b/BlackMarket/Networking/RSAPIError.swift
@@ -1,0 +1,50 @@
+//
+//  RSAPIError.swift
+//  BlackMarket
+//
+//  Created by Santiago Andracchi on 27/09/2023.
+//
+
+import RSSwiftNetworking
+import Foundation
+
+struct RSAPIError: Codable, Error {
+  public let statusCode: Int
+  public let message: String?
+  public let messages: [String]?
+  public let error: String?
+  
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.statusCode = try container.decode(Int.self, forKey: .statusCode)
+    if let messages = try? container.decode([String].self, forKey: .message) {
+      self.messages = messages
+    } else {
+      self.messages = nil
+    }
+    if let message = try? container.decode(String.self, forKey: .message) {
+      self.message = message
+    } else {
+      self.message = nil
+    }
+    
+    self.error = try? container.decode(String.self, forKey: .error)
+  }
+  
+  init(_ error: Error) {
+    self.statusCode = error.asAFError?.responseCode ?? 0
+    self.message = error.localizedDescription
+    self.error = error.localizedDescription
+    self.messages = nil
+  }
+  
+  func getMessage() -> String {
+    if let message = message {
+      return message.capitalizedSentence
+    } else if let message = messages?.first {
+      return message.capitalizedSentence
+    } else {
+      return ""
+    }
+  }
+}

--- a/BlackMarket/Networking/RSApiClient.swift
+++ b/BlackMarket/Networking/RSApiClient.swift
@@ -1,0 +1,162 @@
+//
+//  RSApiClient.swift
+//  rs-admin-ios
+//
+//  Created by Tarek Radovan on 23/01/2023.
+//
+
+import Foundation
+import RSSwiftNetworking
+import UIKit
+
+typealias RSCompletionCallback<T: Decodable> = (
+  _ result: Result<T?, RSAPIError>,
+  _ responseHeaders: [AnyHashable: Any]
+) -> Void
+
+public final class RSApiClient {
+  
+  private let emptyDataStatusCodes: Set<Int> = [204, 205]
+  private let errorStatusCodes: ClosedRange<Int> = 400...499
+  
+  public private(set) var encodingConfiguration: EncodingConfiguration = .default
+  
+  public private(set) var decodingConfiguration: DecodingConfiguration = .default
+  
+  private(set) var headersProvider: HeadersProvider = [:]
+  
+  private let networkProvider: RSNetworkProvider
+  
+  public required init(networkProvider: RSNetworkProvider) {
+    self.networkProvider = networkProvider
+  }
+  
+  public convenience init(
+    networkProvider: RSNetworkProvider,
+    headersProvider: HeadersProvider,
+    encodingConfiguration: EncodingConfiguration = .default,
+    decodingConfiguration: DecodingConfiguration = .default
+  ) {
+    self.init(networkProvider: networkProvider)
+    self.encodingConfiguration = encodingConfiguration
+    self.decodingConfiguration = decodingConfiguration
+    self.headersProvider = headersProvider
+  }
+  
+  @discardableResult
+  func request<T: Decodable>(
+    endpoint: Endpoint,
+    completion: @escaping RSCompletionCallback<T>
+  ) -> Cancellable {
+    networkProvider.request(
+      endpoint: buildAPIEndpoint(from: endpoint)
+    ) { [weak self] result in
+      guard let self = self else { return }
+      
+      self.handle(result, for: endpoint, completion: completion)
+    }
+  }
+  
+  @discardableResult
+  func requestData(endpoint: Endpoint) async -> Result<Data, RSAPIError> {
+    await withCheckedContinuation { continuation in
+      self.requestData(endpoint: endpoint) { result in
+        continuation.resume(returning: result)
+      }
+    }
+  }
+  
+  @discardableResult
+  func requestData(
+    endpoint: Endpoint,
+    completion: @escaping (Result<Data, RSAPIError>) -> Void
+  ) -> Cancellable {
+    networkProvider.request(
+      endpoint: buildAPIEndpoint(from: endpoint)
+    ) { result in
+      if case .success(let response) = result {
+        if let data = response.data {
+          completion(.success(data))
+        }
+      }
+    }
+  }
+  
+  private func handle<T: Decodable>(
+    _ result: Result<Network.Response, RSAPIError>,
+    for endpoint: Endpoint,
+    completion: RSCompletionCallback<T>
+  ) {
+    switch result {
+    case .success(let response):
+      handle(response, with: endpoint.decodingConfiguration, completion: completion)
+    case .failure(let error):
+      completion(.failure(error), [:])
+    }
+  }
+  
+  private func buildAPIEndpoint(from endpoint: Endpoint) -> APIEndpoint {
+    APIEndpoint(endpoint: endpoint, headersProvider: headersProvider)
+  }
+  
+  private func handle<T: Decodable>(
+    _ response: Network.Response,
+    with configuration: DecodingConfiguration?,
+    completion: RSCompletionCallback<T>
+  ) {
+    do {
+      
+      guard
+        !errorStatusCodes.contains(response.statusCode)
+      else {
+        if let data = response.data {
+          let error = try JSONDecoder().decode(RSAPIError.self, from: data)
+          if error.message == Network.StatusCode.unauthorizedIdentifier {
+            SessionManager.shared.deleteSession()
+            return
+          } else {
+            throw error
+          }
+        }
+        return
+      }
+      
+      guard let data = response.data, !data.isEmpty else {
+        guard emptyDataStatusCodes.contains(response.statusCode) else {
+          throw APIClientError.invalidEmptyResponse
+        }
+        
+        return completion(.success(.none), response.headers)
+      }
+      
+      completion(.success(try decode(data, with: configuration)), response.headers)
+    } catch let error {
+      completion(
+        .failure(handleCustomAPIError(from: response) ?? RSAPIError(error)),
+        response.headers
+      )
+    }
+  }
+  
+  private func decode<M: Decodable>(
+    _ data: Data,
+    with configuration: DecodingConfiguration?
+  ) throws -> M {
+    let decoder = JSONDecoder(decodingConfig: configuration ?? decodingConfiguration)
+    return try decoder.decode(M.self, from: data)
+  }
+  
+  private func handleCustomAPIError(from response: Network.Response) -> RSAPIError? {
+    guard let data = response.data else { return nil }
+    do {
+      let errorModel = try JSONDecoder().decode(RSAPIError.self, from: data)
+      return errorModel
+    } catch {
+      return nil
+    }
+  }
+}
+
+extension Network.StatusCode {
+  static let unauthorizedIdentifier = "Unauthorized"
+}

--- a/BlackMarket/Networking/RSNetworkProvider.swift
+++ b/BlackMarket/Networking/RSNetworkProvider.swift
@@ -1,0 +1,85 @@
+//
+//  RSNetworkProvider.swift
+//  rs-admin-ios
+//
+//  Created by Lucas Miotti on 31/01/2023.
+//
+
+import Foundation
+import RSSwiftNetworking
+import Alamofire
+
+// TODO: This will be removed when AlamofireNetworkProvider is open to extend
+/// This should be the only place where the `Alamofire` dependency is imported
+public final class RSNetworkProvider {
+  
+  func request(
+    endpoint: Endpoint,
+    completion: @escaping (Result<Network.Response, RSAPIError>) -> Void
+  ) -> Cancellable {
+    let headers = HTTPHeaders(endpoint.headers)
+    
+    return AF.request(
+      endpoint.requestURL,
+      method: endpoint.method.alamofireMethod,
+      parameters: endpoint.parameters,
+      encoding: endpoint.parameterEncoding.alamofireEncoding,
+      headers: headers
+    )
+    .response { [weak self] afResponse in
+      switch afResponse.result {
+      case.success:
+        self?.handleAlamofireResponse(afResponse, completion: completion)
+      case .failure(let error):
+        completion(.failure(RSAPIError(error)))
+      }
+    }
+  }
+  
+  private func handleAlamofireResponse(
+    _ afResponse: AFDataResponse<Data?>,
+    completion: @escaping (Result<Network.Response, RSAPIError>) -> Void
+  ) {
+    guard let response = afResponse.response else {
+      completion(.failure(RSAPIError(Network.ProviderError.noResponse)))
+      return
+    }
+    
+    completion(.success(Network.Response(
+      statusCode: response.statusCode,
+      data: afResponse.data,
+      headers: response.headers.dictionary
+    )))
+  }
+}
+
+extension Network.HTTPMethod {
+  var alamofireMethod: Alamofire.HTTPMethod {
+    switch self {
+    case .get:
+      return .get
+    case .post:
+      return .post
+    case .put:
+      return .put
+    case .delete:
+      return .delete
+    case .patch:
+      return .patch
+    }
+  }
+}
+
+fileprivate extension RSSwiftNetworking.ParameterEncoding {
+  var alamofireEncoding: Alamofire.ParameterEncoding {
+    switch self {
+    case .httpBody(let format):
+      if format == .json {
+        return JSONEncoding.default
+      }
+      return URLEncoding(destination: .httpBody)
+    case .urlQuery:
+      return URLEncoding(destination: .queryString)
+    }
+  }
+}

--- a/BlackMarket/Networking/RSRequestResponse.swift
+++ b/BlackMarket/Networking/RSRequestResponse.swift
@@ -1,0 +1,26 @@
+//
+//  RSRequestResponse.swift
+//  BlackMarket
+//
+//  Created by Santiago Andracchi on 27/09/2023.
+//
+
+import RSSwiftNetworking
+import Foundation
+
+typealias RSRequestResponse<T: Decodable> = (
+  result: Result<T?, RSAPIError>,
+  responseHeaders: [AnyHashable: Any]
+)
+
+extension RSApiClient {
+  
+  @discardableResult
+  func request<T: Decodable>(endpoint: Endpoint) async -> RSRequestResponse<T> {
+    await withCheckedContinuation { continuation in
+      self.request(endpoint: endpoint) { result, responseHeaders in
+        continuation.resume(returning: (result, responseHeaders))
+      }
+    }
+  }
+}

--- a/BlackMarket/Networking/Services/ProductServices.swift
+++ b/BlackMarket/Networking/Services/ProductServices.swift
@@ -1,0 +1,56 @@
+//
+//  ProductsService.swift
+//  BlackMarket
+//
+//  Created by Santiago Andracchi on 28/09/2023.
+//
+
+import Foundation
+
+internal class ProductServices: ProductServicesProtocol {
+  
+  private let apiClient: RSApiClient
+  
+  enum ProductError: Error {
+    case noProductsFound
+    case noPictureFound
+  }
+  
+  init(
+    apiClient: RSApiClient = RSApiClient.shared
+  ) {
+    self.apiClient = apiClient
+  }
+  
+  func getProducts(
+    page: Int,
+    pageSize: Int,
+    search: String?
+  ) async -> Result<PagedResponse<[Product]>, RSAPIError> {
+    let response: RSRequestResponse<PagedResponse<[Product]>> = await apiClient.request(
+      endpoint: ProductEndpoint.getProducts(
+        page: page,
+        pageSize: pageSize,
+        search: search)
+    )
+    switch response.result {
+    case .success(let productList):
+      guard let ticketList = productList else {
+        return .failure(RSAPIError(ProductError.noProductsFound))
+      }
+      return .success(ticketList)
+    case .failure(let error):
+      return .failure(error)
+    }
+  }
+}
+
+protocol ProductServicesProtocol {
+  
+  func getProducts(
+    page: Int,
+    pageSize: Int,
+    search: String?
+  ) async -> Result<PagedResponse<[Product]>, RSAPIError>
+  
+}

--- a/BlackMarket/Views/Dashboard/DashboardView.swift
+++ b/BlackMarket/Views/Dashboard/DashboardView.swift
@@ -8,15 +8,21 @@
 import SwiftUI
 
 struct DashboardView: View {
+
   @EnvironmentObject var modelData: ModelData
+  @ObservedObject private var viewModel: DashboardViewModel
   
+  init(viewModel: DashboardViewModel = DashboardViewModel()) {
+    self.viewModel = viewModel
+  }
+
   var body: some View {
     VStack {
       ScrollView {
         Spacer().frame(height: 1)
         HeaderView()
         SearchProductsView()
-        ProductListView(items: modelData.products)
+        ProductListView(items: viewModel.productList)
         PromoDiscountView().background(Color.lightGray)
         PaymentMethodsView()
         PromoShipmentsView().background(Color.lightGray)

--- a/BlackMarket/Views/Dashboard/DashboardViewModel.swift
+++ b/BlackMarket/Views/Dashboard/DashboardViewModel.swift
@@ -1,0 +1,51 @@
+//
+//  DashboardViewModel.swift
+//  BlackMarket
+//
+//  Created by Santiago Andracchi on 28/09/2023.
+//
+
+import Foundation
+import Combine
+import SwiftUI
+
+final class DashboardViewModel: ObservableObject {
+  
+  @Published var isLoading: Bool = false
+  @Published var productsAlreadyFetched: Bool = false
+  @Published var productsManager: ProductsManager
+  @Published var productList: [Product] = []
+  private var cancelBag = Set<AnyCancellable>()
+  
+  init(productsManager: ProductsManager = ProductsManager(service: ProductServices(), pageSize: ProductsPaging.dashboardPageSize)) {
+    self.productsManager = productsManager
+    
+    productsManager.$products
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] products in
+        self?.productList = products
+        self?.productsAlreadyFetched = true
+      }.store(in: &cancelBag)
+    
+    fetchData()
+  }
+  
+  @MainActor
+  func fetchProducts() {
+    isLoading = true
+    Task {
+      await productsManager.getProducts()
+      productsAlreadyFetched = true
+      isLoading = false
+    }
+  }
+  
+  func fetchData() {
+    guard !productsAlreadyFetched else {
+      return
+    }
+    Task {
+      await fetchProducts()
+    }
+  }
+}

--- a/BlackMarket/Views/Dashboard/ProductItemView.swift
+++ b/BlackMarket/Views/Dashboard/ProductItemView.swift
@@ -13,8 +13,13 @@ struct ProductItemView: View {
   
   var body: some View {
     VStack(alignment: .center) {
-      Image(ImageNames.blackmarketChair)
-        .frame(width: 136, height: 120)
+      AsyncImage(url: URL(string: product.productPicture)) { image in
+        image
+          .resizable()
+          .frame(width: 136, height: 120)
+      } placeholder: {
+        ProgressView().progressViewStyle(.circular)
+      }
       Spacer().frame(height: 8)
       HStack {
         Text(product.unitPrice).font(.system(size: 14))


### PR DESCRIPTION
- I created all the necessary classes to fetch the product list and display it on the dashboard view.
- I added `RSSwiftNetworking` and `Alamofire` using Swift Package Manager (`SPM`) to achieve this.
- To handle asynchronous API calls, I use the `DashViewModelViewModel` with the `ObservableObject` protocol and the Published property wrapper to update the `SwiftUI` view."

Note: Handling of session data during login or signup will be addressed in another pull request, as well as the handling of displaying product list images.